### PR TITLE
Temporary solution to #104.

### DIFF
--- a/src/main/java/edu/usc/softarch/arcade/facts/issues/handlers/GitLabRestHandler.java
+++ b/src/main/java/edu/usc/softarch/arcade/facts/issues/handlers/GitLabRestHandler.java
@@ -268,17 +268,9 @@ public class GitLabRestHandler {
 				// Unknown purpose fields
 				case "milestone":
 					skipToNextField(parser);
-//					String milestone = parser.getText();
-//					if (!milestone.equals("null"))
-//						throwLocalException("New milestone identified: "
-//							+ milestone + ", in issue ID: "	+ issueBuilder.id);
 					break;
 				case "issue_type":
 					skipToNextField(parser);
-//					String issueType = parser.getText();
-//					if (!issueType.equals("issue"))
-//						throwLocalException("New issue type identified: "
-//							+ issueType	+ ", in issue ID: " + issueBuilder.id);
 					break;
 				case "severity":
 					String severity = parser.getText();
@@ -288,17 +280,9 @@ public class GitLabRestHandler {
 					break;
 				case "type":
 					skipToNextField(parser);
-					//issueBuilder.type = getTextIfNotNull(parser);
-					//if (!issueBuilder.type.equals("ISSUE"))
-					//	throwLocalException("New type identified: "
-					//		+ issueBuilder.type + ", in issue ID: " + issueBuilder.id);
 					break;
 				case "weight":
 					skipToNextField(parser);
-//					String weight = parser.getText();
-//					if (!weight.equals("null"))
-//						throwLocalException("New weight identified: "
-//							+ weight + ", in issue ID: " + issueBuilder.id);
 					break;
 				case "prepared_at":
 					skipToNextField(parser);
@@ -438,10 +422,6 @@ public class GitLabRestHandler {
 					break;
 				// Unknown purpose fields
 				case "milestone":
-//					String milestone = parser.getText();
-//					if (!milestone.equals("null"))
-//						throwLocalException("New milestone identified: "
-//							+ milestone	+ ", in issue ID: " + commitBuilder.id);
 					skipToNextField(parser);
 					break;
 				case "prepared_at":

--- a/src/main/java/edu/usc/softarch/arcade/facts/issues/handlers/GitLabRestHandler.java
+++ b/src/main/java/edu/usc/softarch/arcade/facts/issues/handlers/GitLabRestHandler.java
@@ -274,10 +274,11 @@ public class GitLabRestHandler {
 //							+ milestone + ", in issue ID: "	+ issueBuilder.id);
 					break;
 				case "issue_type":
-					String issueType = parser.getText();
-					if (!issueType.equals("issue"))
-						throwLocalException("New issue type identified: "
-							+ issueType	+ ", in issue ID: " + issueBuilder.id);
+					skipToNextField(parser);
+//					String issueType = parser.getText();
+//					if (!issueType.equals("issue"))
+//						throwLocalException("New issue type identified: "
+//							+ issueType	+ ", in issue ID: " + issueBuilder.id);
 					break;
 				case "severity":
 					String severity = parser.getText();
@@ -286,10 +287,11 @@ public class GitLabRestHandler {
 							+ severity + ", in issue ID: " + issueBuilder.id);
 					break;
 				case "type":
-					issueBuilder.type = getTextIfNotNull(parser);
-					if (!issueBuilder.type.equals("ISSUE"))
-						throwLocalException("New type identified: "
-							+ issueBuilder.type + ", in issue ID: " + issueBuilder.id);
+					skipToNextField(parser);
+					//issueBuilder.type = getTextIfNotNull(parser);
+					//if (!issueBuilder.type.equals("ISSUE"))
+					//	throwLocalException("New type identified: "
+					//		+ issueBuilder.type + ", in issue ID: " + issueBuilder.id);
 					break;
 				case "weight":
 					skipToNextField(parser);
@@ -297,6 +299,9 @@ public class GitLabRestHandler {
 //					if (!weight.equals("null"))
 //						throwLocalException("New weight identified: "
 //							+ weight + ", in issue ID: " + issueBuilder.id);
+					break;
+				case "prepared_at":
+					skipToNextField(parser);
 					break;
 				case "epic":
 					String epic = parser.getText();
@@ -437,6 +442,9 @@ public class GitLabRestHandler {
 //					if (!milestone.equals("null"))
 //						throwLocalException("New milestone identified: "
 //							+ milestone	+ ", in issue ID: " + commitBuilder.id);
+					skipToNextField(parser);
+					break;
+				case "prepared_at":
 					skipToNextField(parser);
 					break;
 				// Useful fields

--- a/src/main/java/edu/usc/softarch/arcade/util/McfpDriver.java
+++ b/src/main/java/edu/usc/softarch/arcade/util/McfpDriver.java
@@ -60,7 +60,8 @@ public class McfpDriver {
 
 		for (Map.Entry<String, ReadOnlyCluster> cluster1 : arch1.entrySet()) {
 			// Create vertex for the source cluster
-			String vertex1 = "source_" + cluster1.getKey();
+			validateClusterName("source_202311111800_", cluster1.getKey());
+			String vertex1 = "source_202311111800_" + cluster1.getKey();
 			graph.addVertex(vertex1);
 
 			//Create edge from source to new vertex1
@@ -72,7 +73,8 @@ public class McfpDriver {
 					cluster1.getValue().symmetricDifferenceSize(cluster2.getValue());
 
 				// Create vertex for the target cluster
-				String vertex2 = "target_" + cluster2.getKey();
+				validateClusterName("target_202311111800_", cluster2.getKey());
+				String vertex2 = "target_202311111800_" + cluster2.getKey();
 				if (firstPass) {
 					graph.addVertex(vertex2);
 					// Create edge to sink if it's the first pass
@@ -124,8 +126,8 @@ public class McfpDriver {
 		Map<String, String> result = new HashMap<>();
 
 		for (DefaultWeightedEdge edge : changeSet) {
-			String source = graph.getEdgeSource(edge).replace("source_", "");
-			String target = graph.getEdgeTarget(edge).replace("target_", "");
+			String source = graph.getEdgeSource(edge).replace("source_202311111800_", "");
+			String target = graph.getEdgeTarget(edge).replace("target_202311111800_", "");
 			result.put(source, target);
 		}
 
@@ -140,6 +142,25 @@ public class McfpDriver {
 
 		for (int i = 0; i < dummyCount; i++)
 			smallerArch.put("dummy" + i, new ReadOnlyCluster("dummy" + i));
+	}
+	/**
+	 * Validate the original name from the project to avoid crashing with the appended prefix in this class.
+	 * E.g, if there is a identical string in the original name of the cluster, the replacement in the bottom of this file will replace the original one in additional to the following appended prefix.
+	 *
+	 * @param prefix The appended prefix in this class.
+	 * @param clusterName The cluster name.
+	 * @return void
+	 */
+	private void validateClusterName(
+			String prefix, String clusterName) {
+
+		try {
+			if (clusterName.contains(prefix)){
+				throw new Exception("Cluster names matches the appended prefix in the ARCADE source code.");
+			}
+		} catch (Exception e) {
+			System.out.println("Exception caught: " + e.getMessage());
+		}
 	}
 	//endregion
 }


### PR DESCRIPTION
The issue actually was caused by two problems:
1. The REST API v4 has been changed. I have added a new entry in the API parser.
2. In **McfpDriver**, there are hard-coded appended prefixes to the cluster names. If those prefixes, **"source_"** and **"target_"** exist in the original names, the original portion will also be replaced in the same class which will cause a **NullPointerException**. The temporary solution is to change the prefixes to more complex replacements and add checkers to make sure the problem will be correctly detected if it happens again for some projects.