### PR TITLE
Updated CLI to disable mandatory toLowerCase() for all parameters.

### DIFF
--- a/src/main/java/edu/usc/softarch/arcade/util/CLI.java
+++ b/src/main/java/edu/usc/softarch/arcade/util/CLI.java
@@ -5,6 +5,8 @@ import edu.usc.softarch.util.Terminal;
 import java.util.HashMap;
 import java.util.Map;
 
+// TODO: The arguments are forced to lower cases which causes problems when parsing versions for projects like struts which have upper case version tags.
+
 public class CLI {
 	public static Map<String, String> parseArguments(String[] args) {
 		Map<String, String> result = new HashMap<>();
@@ -24,8 +26,14 @@ public class CLI {
 			}
 
 			// Argument is a value
-			if (arg.contains("=")) {
-				String[] argKeyValue = arg.toLowerCase().split("=");
+			if (arg.contains("=")){
+				String[] argKeyValue = null;
+				if(arg.contains("projversion") || arg.contains("deps") || arg.contains("projpath")){
+					argKeyValue = arg.split("=");
+				}
+				else{
+					argKeyValue = arg.toLowerCase().split("=");
+				}
 
 				// Message level argument
 				if (argKeyValue[0].equals("messagelevel"))
@@ -67,7 +75,7 @@ public class CLI {
 				break;
 			default:
 				throw new IllegalArgumentException(
-					"Unknown messagelevel " + argument);
+						"Unknown messagelevel " + argument);
 		}
 	}
 }


### PR DESCRIPTION
Updated CLI to disable mandatory toLowerCase() for all parameters. #109 

Hi, @MarceloLaser, just want to let you know that I just made some updates to the CLI.java to disable mandatory toLowerCase() for all parameters because it causes failures on project such as Apache struts. See #109 for details.

If you have time, please take a look to make sure it won't cause unexpected problems in the steps after clustering.
I'm running it on struts right now and everything looks fine.